### PR TITLE
.github/fetch-and-ingest: define artifact-paths

### DIFF
--- a/.github/workflows/fetch-and-ingest.yaml
+++ b/.github/workflows/fetch-and-ingest.yaml
@@ -78,3 +78,9 @@ jobs:
       env: |
         S3_DST: ${{ needs.set_config_overrides.outputs.s3_dst }}
         TRIGGER_REBUILD: ${{ needs.set_config_overrides.outputs.trigger_rebuild }}
+      artifact-name: ingest-build-output
+      artifact-paths: |
+        ingest/results/
+        ingest/benchmarks/
+        ingest/logs/
+        ingest/.snakemake/log/


### PR DESCRIPTION
## Description of proposed changes

The default artifact-paths do not wokr for ingest so the workflow must define custom artifact-paths. Noticed this workflow was not uploading artifacts when investigating a failed workflow

<https://github.com/nextstrain/chikv/actions/runs/26112875396>

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass
- [ ] ~Update changelog~

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
